### PR TITLE
Adds jasmine tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utility functions for front-end JavaScript development.",
   "main": "utilities.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jasmine"
   },
   "repository": {
     "type": "git",
@@ -15,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/theZieger/utilitiesjs/issues"
   },
-  "homepage": "https://github.com/theZieger/utilitiesjs#readme"
+  "homepage": "https://github.com/theZieger/utilitiesjs#readme",
+  "devDependencies": {
+    "jasmine": "^2.6.0"
+  }
 }

--- a/spec/inherits.js
+++ b/spec/inherits.js
@@ -1,0 +1,59 @@
+var utilities = require('../utilities.min.js');
+
+describe("utilities.inherits", function() {
+
+    // test example fron README.md
+    var SuperClass = function() {
+        this.someProperty = 42;
+    };
+
+    SuperClass.prototype.retMsg = function(msg) {
+        return msg;
+    };
+    
+    SuperClass.prototype.getSomeProp = function() {
+        return this.someProperty;
+    };
+
+    // a class we want to inherit from SuperClass
+    var SomeClass = function() {
+        SuperClass.call(this);
+    };
+
+    utilities.inherits(SomeClass, SuperClass);
+
+    SomeClass.prototype.flop = function(msg) {
+        return this.retMsg(msg);
+    };
+
+    var someClass_instance = new SomeClass();
+    // end test example from README.md
+
+    it("should be able to access inherited properties", function() {
+        expect(someClass_instance.someProperty).toEqual(42);
+    });
+
+    it("should be able to run inherited methods", function() {
+        expect(someClass_instance.retMsg('hi')).toEqual('hi');
+    });
+
+    it("should be able to run inherited methods by using the this keyword", function() {
+        expect(someClass_instance.flop('hi')).toEqual('hi');
+    });
+
+    it("should be instance of SomeClass", function() {
+        expect((someClass_instance instanceof SomeClass)).toEqual(true);
+    });
+
+    it("should be instance of SuperClass", function() {
+        expect((someClass_instance instanceof SuperClass)).toEqual(true);
+    });
+
+    it("should set SuperClass contructor", function() {
+        expect(someClass_instance.constructor.super_ === SuperClass).toEqual(true);
+    });
+
+    it("should set contructor", function() {
+        expect(someClass_instance.constructor === SomeClass).toEqual(true);
+    });
+});

--- a/spec/inherits.js
+++ b/spec/inherits.js
@@ -1,8 +1,7 @@
-var utilities = require('../utilities.min.js');
+var utilities = require('../utilities.js');
 
-describe("utilities.inherits", function() {
-
-    // test example fron README.md
+describe('utilities.inherits', function() {
+    // test example from README.md
     var SuperClass = function() {
         this.someProperty = 42;
     };
@@ -10,7 +9,7 @@ describe("utilities.inherits", function() {
     SuperClass.prototype.retMsg = function(msg) {
         return msg;
     };
-    
+
     SuperClass.prototype.getSomeProp = function() {
         return this.someProperty;
     };

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/spec/toObject.js
+++ b/spec/toObject.js
@@ -1,0 +1,47 @@
+var utilities = require('../utilities.js');
+
+describe('utilities.toObject', function() {
+    describe('array of primitives toObject', function() {
+        // test example from README.md
+        var states = ['Sachsen', 'Sachsen-Anhalt', 'Berlin', 'Hamburg'];
+        var statesObject = utilities.toObject(states);
+        // end test example from README.md
+
+        it("should be able to access object by index", function() {
+            expect(statesObject[0]).toEqual('Sachsen');
+        });
+
+        it("should have 4 keys", function() {
+            expect(Object.keys(statesObject).length).toEqual(4);
+        });
+    });
+
+    describe('array of objects toObject', function() {
+        // test example from README.md
+        var news = [
+            {
+                id: 12001,
+                headline: 'Tiger goes limp',
+                subHeadline: 'Pulls out after 9 holes'
+            },{
+                id: 666,
+                headline: 'Croc has beef with cow',
+                subHeadline: ''
+            },{
+                id: 1337,
+                headline: 'Germans wurst at penalties',
+                subHeadline: 'New stats prove England are better from the spot'
+            }
+        ];
+        var newsObject = utilities.toObject(news, 'id');
+        // end test example from README.md
+
+        it("should be able to access object by ID", function() {
+            expect(newsObject[1337].headline).toEqual('Germans wurst at penalties');
+        });
+
+        it("should have 3 keys", function() {
+            expect(Object.keys(newsObject).length).toEqual(3);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #7 by adding jasmine tests for the existing code.
The tests can be run via `npm test` command from the command line interface after running `npm install` to install all the dev-dependencies.