### PR TITLE
fixes #12 by adding global comment

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -4,8 +4,10 @@
  * https://github.com/theZieger/utilitiesjs/blob/master/LICENSE
  */
 (function(root, factory) {
+    /** global: define */
     if (typeof define === "function" && define.amd) {
         define(["utilities"], factory);
+    /** global: module */
     } else if (typeof module === "object" && module.exports) {
         module.exports = factory();
     } else {


### PR DESCRIPTION
The variable define and module seems to be never declared. Since they are expected globals I added the  /** global: define */ comment.