### PR TITLE
Add combined id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# utilities v0.8.1 [![Build Status](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/badges/build.png?b=master)](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/build-status/master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/?branch=master) [![Code Coverage](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/?branch=master) 
+# utilities v0.8.1 [![Build Status](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/badges/build.png?b=master)](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/build-status/master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/?branch=master) [![Code Coverage](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/theZieger/utilitiesjs/?branch=master)
 
 > Utility functions for front-end JavaScript development.
 
@@ -57,6 +57,13 @@ Turns an array of values into a object.
 
 The `mapBy` argument is therefore totally optional.
 
+`mapBy` can be a simple string (referring to an property name of the objects inside `arr`), an array of strings (referring to an property name of the objects inside `arr`) or an function returning a property name which is used to store the reference to the original object of `arr` in the returned object.
+
+When mapBy is a function it will take three arguments:
+1. `val` - the current object which is processed
+1. `i` - the index of the current object which is processed
+1. `arr` - the array given to toObject as first parameter
+
 This function was created because I, as a front-end developer, have to handle a lot of data from API responses. And when I say a lot, I mean a lot.
 Sometimes more than 2000 objects inside an array with countless attributes hit our clients and I have to enrich them with even more data from different API requests.
 You can imagine looping over those 2000 objects can be tough for the clients device. So I map these array of objects to an associative object which can be accessed a lot faster by simply doing a member access by the ID.
@@ -94,15 +101,33 @@ var news = [
         subHeadline: 'New stats prove England are better from the spot'
     }
 ];
-var newsObject = utilities.toObject(news, 'id');
 
-console.log(newsObject);
+var newsObject1 = utilities.toObject(news, 'id');
+var newsObject2 = utilities.toObject(news, ['id', 'id']);
+var newsObject3 = utilities.toObject(news, function(val, i) {
+    return val.id + '_' + i;
+});
 
+console.log(newsObject1);
 // results in:
 // {
-//     12001: { id: 12001, headline: 'Tiger goes limp', subHeadline: 'Pulls out after 9 holes' },
-//     666: { id: 666, headline: 'Croc has beef with cow', subHeadline: '' },
-//     1337: { id: 1337, headline: 'Germans wurst at penalties', subHeadline: 'New stats prove England are better from the spot' }
+//     '12001': { id: 12001, headline: 'Tiger goes limp', subHeadline: 'Pulls out after 9 holes' },
+//     '666': { id: 666, headline: 'Croc has beef with cow', subHeadline: '' },
+//     '1337': { id: 1337, headline: 'Germans wurst at penalties', subHeadline: 'New stats prove England are better from the spot' }
+
+console.log(newsObject2);
+// results in:
+// {
+//     '12001_12001': { id: 12001, headline: 'Tiger goes limp', subHeadline: 'Pulls out after 9 holes' },
+//     '666_666': { id: 666, headline: 'Croc has beef with cow', subHeadline: '' },
+//     '1337_1337': { id: 1337, headline: 'Germans wurst at penalties', subHeadline: 'New stats prove England are better from the spot' }
+
+console.log(newsObject3);
+// results in:
+// {
+//     '12001_0': { id: 12001, headline: 'Tiger goes limp', subHeadline: 'Pulls out after 9 holes' },
+//     '666_1': { id: 666, headline: 'Croc has beef with cow', subHeadline: '' },
+//     '1337_2': { id: 1337, headline: 'Germans wurst at penalties', subHeadline: 'New stats prove England are better from the spot' }
 // }
 
 ```

--- a/spec/toObject.js
+++ b/spec/toObject.js
@@ -71,7 +71,7 @@ describe('utilities.toObject', function() {
     });
 
     describe('array of objects toObject - function mapBy', function() {
-        var newsObject = utilities.toObject(news, function(val, i, arr) {
+        var newsObject = utilities.toObject(news, function(val, i) {
             return val.id + '_' + i;
         });
 

--- a/spec/toObject.js
+++ b/spec/toObject.js
@@ -10,7 +10,7 @@ describe('utilities.toObject', function() {
             expect(utilities.toObject.bind(null, {})).toThrowError(TypeError);
         });
 
-        it("should fail because the mapBy not of type String and not falsy", function() {
+        it("should fail because the mapBy not of type String, Array or Function and not falsy", function() {
             expect(utilities.toObject.bind(null, [], {})).toThrowError(TypeError);
         });
     });
@@ -30,28 +30,53 @@ describe('utilities.toObject', function() {
         });
     });
 
-    describe('array of objects toObject', function() {
-        // test example from README.md
-        var news = [
-            {
-                id: 12001,
-                headline: 'Tiger goes limp',
-                subHeadline: 'Pulls out after 9 holes'
-            },{
-                id: 666,
-                headline: 'Croc has beef with cow',
-                subHeadline: ''
-            },{
-                id: 1337,
-                headline: 'Germans wurst at penalties',
-                subHeadline: 'New stats prove England are better from the spot'
-            }
-        ];
+    var news = [
+        {
+            id: 12001,
+            headline: 'Tiger goes limp',
+            subHeadline: 'Pulls out after 9 holes'
+        },{
+            id: 666,
+            headline: 'Croc has beef with cow',
+            subHeadline: ''
+        },{
+            id: 1337,
+            headline: 'Germans wurst at penalties',
+            subHeadline: 'New stats prove England are better from the spot'
+        }
+    ];
+
+    describe('array of objects toObject - string mapBy', function() {
         var newsObject = utilities.toObject(news, 'id');
-        // end test example from README.md
 
         it("should be able to access object by ID", function() {
             expect(newsObject[1337].headline).toEqual('Germans wurst at penalties');
+        });
+
+        it("should have 3 keys", function() {
+            expect(Object.keys(newsObject).length).toEqual(3);
+        });
+    });
+
+    describe('array of objects toObject - array mapBy', function() {
+        var newsObject = utilities.toObject(news, ['id', 'id']);
+
+        it("should be able to access object by ID_ID", function() {
+            expect(newsObject['1337_1337'].headline).toEqual('Germans wurst at penalties');
+        });
+
+        it("should have 3 keys", function() {
+            expect(Object.keys(newsObject).length).toEqual(3);
+        });
+    });
+
+    describe('array of objects toObject - function mapBy', function() {
+        var newsObject = utilities.toObject(news, function(val, i, arr) {
+            return val.id + '_' + i;
+        });
+
+        it("should be able to access object by ID_index", function() {
+            expect(newsObject['1337_2'].headline).toEqual('Germans wurst at penalties');
         });
 
         it("should have 3 keys", function() {

--- a/utilities.js
+++ b/utilities.js
@@ -95,7 +95,7 @@
             string: function(val) {
                 this.undefined(val, val[mapBy]);
             },
-            object: function(val, i) {
+            object: function(val) {
                 var newKey = mapBy.map(function(propertyName){
                     return val[propertyName];
                 }).join('_');

--- a/utilities.js
+++ b/utilities.js
@@ -17,10 +17,11 @@
 
     /**
      * inherit the prototype of the SuperConstructor
-     * 
-     * Warning: Changing the prototype of an object is, by the nature of how modern JavaScript engines
-     * optimize property accesses, a very slow operation, in every browser and JavaScript engine.
-     * So instead of using Object.setPrototypeOf or messing with __proto__, we create a new object
+     *
+     * Warning: Changing the prototype of an object is, by the nature of how
+     * modern JavaScript engines optimize property accesses, a very slow
+     * operation, in every browser and JavaScript engine. So instead of using
+     * Object.setPrototypeOf or messing with __proto__, we create a new object
      * with the desired prototype using Object.create().
      *
      * @see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
@@ -28,7 +29,8 @@
      * @param {Object} Constructor
      * @param {Object} SuperConstructor
      *
-     * @throws {TypeError} if arguments are null/undefined, or SuperConstructor has no prototype
+     * @throws {TypeError} if arguments are `null`, `undefined`, or
+     *                     `SuperConstructor` has no prototype
      *
      * @returns {Void}
      */
@@ -45,7 +47,10 @@
             throw new TypeError('SuperConstructor.prototype is undefined');
         }
 
-        // for convenience, SuperConstructor will be accessible through the Constructor.super_ property
+        /**
+         * for convenience, `SuperConstructor` will be accessible through the
+         * `Constructor.super_` property
+         */
         Constructor.super_ = SuperConstructor;
 
         Constructor.prototype = Object.create(SuperConstructor.prototype);
@@ -53,37 +58,72 @@
     };
 
     /**
-     * Turns Array (of Objects) into associative Object (by given mapBy when given)
+     * Turns an Array into an associative Object (while keeping reference!)
      *
-     * @param {Array}  arr
-     * @param {String} mapBy  optional mapping key
+     * @param {Array}                 arr    Array of Objects to turn into an
+     *                                       associative Object
+     * @param {String|Array|Function} mapBy  optional mapping key, can be a
+     *                                       simple string (property name in
+     *                                       the abjects of arr), a list of
+     *                                       property names (which are
+     *                                       combined) or a function which
+     *                                       returns a unique id to use
      *
-     * @throws {TypeError} if arr is not an Array or mapBy is set but not a String
+     * @throws {TypeError} if arr is not an Array or mapBy is set but not of
+     *                     correct type (String, Array, Function)
      *
      * @returns {Object}
      */
     var toObject = function(arr, mapBy) {
         var obj = {};
-      
+
         if (!Array.isArray(arr)) {
             throw new TypeError('arr argument is not of type Array');
         }
 
-        if (mapBy !== undefined && typeof mapBy !== 'string') {
-            throw new TypeError('mapBy argument is not of type String');
+        if (mapBy !== undefined
+            && typeof mapBy !== 'string'
+            && !Array.isArray(mapBy)
+            && typeof mapBy !== 'function'
+        ) {
+            throw new TypeError(
+                'mapBy argument is not of type {String|Array|Function}'
+            );
         }
 
-        arr.forEach(function(val, i) {
-            if (!mapBy) {
-                obj[i] = val;
-            } else if (
-                typeof val[mapBy] === 'string'
-                || typeof val[mapBy] === 'number'
-            ) {
-                obj[val[mapBy]] = val;
+        var methods = {
+            string: function(val) {
+                this.undefined(val, val[mapBy]);
+            },
+            object: function(val, i) {
+                var newKey = mapBy.map(function(propertyName){
+                    return val[propertyName];
+                }).join('_');
+
+                this.undefined(val, newKey);
+            },
+            function: function(val, i, arr) {
+                this.undefined(val, mapBy(val, i, arr));
+            },
+            undefined: function(val, newKey) {
+                if (typeof newKey === 'string'
+                    || typeof newKey === 'number'
+                ) {
+                    obj[newKey] = val;
+                }
             }
-        });
-      
+        };
+
+        /**
+         * run the designated method by mapBy type from the methods object
+         * it binds the methods object so we can use the undefined setter method
+         * for different mapBy types and don't have to maintain multiple but
+         * same conditions
+         */
+        arr.forEach(
+            methods[(typeof mapBy)].bind(methods)
+        );
+
         return obj;
     };
 


### PR DESCRIPTION
Fixes #17 so that `mapBy` can be a string, array or function to determine under which new key to store the reference to the original object.